### PR TITLE
Don't clear endpoint cache on terminal method

### DIFF
--- a/src/fluent_discourse/discourse.py
+++ b/src/fluent_discourse/discourse.py
@@ -62,7 +62,6 @@ class Discourse:
             return self._handle_error(r, method, url, data, params)
 
     def _handle_error(self, response, method, url, data, params):
-        self._cache = []
         if response.status_code == 404:
             raise PageNotFoundError(
                 f"The requested page was not found, or you do not have permission to access it: {response.url}"
@@ -94,25 +93,21 @@ class Discourse:
     def get(self, data=None):
         # Make a get request
         url = self._make_url()
-        self._cache = []
         return self._request("GET", url, params=data)
 
     def post(self, data=None):
         # Make a post request
         url = self._make_url()
-        self._cache = []
         return self._request("POST", url, data=data)
 
     def put(self, data=None):
         # Make a put request
         url = self._make_url()
-        self._cache = []
         return self._request("PUT", url, data=data)
 
     def delete(self, data=None):
         # Make a delete request
         url = self._make_url()
-        self._cache = []
         return self._request("DELETE", url, data=data)
 
     def _make_url(self):

--- a/tests/0_unit_test.py
+++ b/tests/0_unit_test.py
@@ -2,6 +2,7 @@ from conf_tests import BASE_URL, client, USERNAME, API_KEY
 from fluent_discourse import *
 import pytest
 import json
+from unittest.mock import patch
 
 
 def test_accumulate_strings(client):
@@ -72,3 +73,18 @@ def test_wait_for_rate_limit():
     MockResponse.status_code = 429
     client = Discourse.from_env(raise_for_rate_limit=False)
     client._wait_for_rate_limit(MockResponse, "GET", None, None, None)
+
+
+def test_reuse_endpoint(client):
+    with patch("fluent_discourse.Discourse._request"):
+        endpoint = client.test.a.path
+        assert endpoint._cache == ["test", "a", "path"]
+        endpoint.get({"foo": "bar"})
+        assert endpoint._cache == ["test", "a", "path"]
+
+
+def test_reuse_client(client):
+    with patch("fluent_discourse.Discourse._request"):
+        client.test.a.path.get()
+        endpoint = client.foo.bar
+        assert endpoint._cache == ["foo", "bar"]


### PR DESCRIPTION
## What

The endpoint cache was being cleared on each terminal method (get, post, put, delete). This resulted in endpoints not being reusable.

For example:
```python
endpoint = admin.users.list.new.json
endpoint.get({'page':1})
endpoint.get({'page': 2})
```

## Issues

Resolves https://github.com/graydenshand/fluent_discourse/issues/1

## Tests

Two unit tests were added to verify the expected behavior.